### PR TITLE
fix: Properly join path segments

### DIFF
--- a/discordrp/presence.py
+++ b/discordrp/presence.py
@@ -122,9 +122,9 @@ class Presence:
         for env in ('XDG_RUNTIME_DIR', 'TMPDIR', 'TMP', 'TEMP'):
             path = os.environ.get(env)
             if path is not None:
-                return path + SOCKET_NAME
+                return os.path.join(path, SOCKET_NAME)
 
-        return '/tmp/' + SOCKET_NAME
+        return os.path.join('/tmp/', SOCKET_NAME)
 
     def _try_socket(self, pipe: str, i: int):
         if self._platform == WINDOWS:


### PR DESCRIPTION
On my linux machine, XDG_RUNTIME_DIR is /run/user/1000, which means that simply adding the strings results the incorrect path `/run/user/1000discord-ipc-0`. In turn this raises `PresenceError('Cannot find a socket to connect to Discord')`. Using os.path.join fixes this issue.