### PR TITLE
Typing and export PresenceError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__/
 dist/
+.mypy_cache/
 *.egg-info/
 *.pyc
 

--- a/discordrp/__init__.py
+++ b/discordrp/__init__.py
@@ -2,11 +2,11 @@
 A lightweight and safe module for creating custom rich presences on Discord.
 """
 
-from .presence import Presence
+from .presence import Presence, PresenceError
 
 __title__ = 'discord-rich-presence'
 __author__ = 'TenType'
 __copyright__ = 'Copyright 2022 TenType'
 __license__ = 'MIT'
 __version__ = '1.0.2'
-__all__ = ("Presence", )
+__all__ = ("Presence", "PresenceError")

--- a/discordrp/__init__.py
+++ b/discordrp/__init__.py
@@ -9,3 +9,4 @@ __author__ = 'TenType'
 __copyright__ = 'Copyright 2022 TenType'
 __license__ = 'MIT'
 __version__ = '1.0.2'
+__all__ = ("Presence", )

--- a/discordrp/presence.py
+++ b/discordrp/presence.py
@@ -164,7 +164,7 @@ class _UnixSocket(_Socket):
         # Try to connect to a socket, starting from 0 up to 9
         for i in range(10):
             try:
-                self._sock = socket.socket(socket.AF_UNIX)
+                self._sock = socket.socket(socket.AF_UNIX)  # type: ignore [attr-defined,unused-ignore]
                 self._sock.connect(pipe.format(i))
                 break
             except FileNotFoundError:

--- a/discordrp/presence.py
+++ b/discordrp/presence.py
@@ -4,6 +4,7 @@ import socket
 import struct
 import sys
 
+from abc import ABC, abstractmethod
 from enum import IntEnum
 from typing import Any, cast
 from types import TracebackType
@@ -13,6 +14,7 @@ class OpCode(IntEnum):
     """
     A list of valid opcodes that can be sent in packets to Discord.
     """
+
     HANDSHAKE = 0
     FRAME = 1
     CLOSE = 2
@@ -35,11 +37,10 @@ class Presence:
 
     def __init__(self, client_id: str):
         self.client_id = client_id
-        self._socket: Any = None
 
         # Connect to Discord IPC
-        self._connect()
-
+        self._socket: _Socket = _WindowsSocket() if sys.platform == 'win32' else _UnixSocket()
+    
         # Send a handshake request
         self._handshake()
 
@@ -98,58 +99,20 @@ class Presence:
         This method is automatically called when the program exits using the 'with' statement.
         """
         self._send({}, OpCode.CLOSE)
-        self._socket.close()
-
-    def _connect(self) -> None:
-        pipe = self._get_pipe()
-
-        # Try to connect to a socket, starting from 0 up to 9
-        for i in range(10):
-            try:
-                self._try_socket(pipe, i)
-                break
-            except FileNotFoundError:
-                pass
-        else:
-            raise PresenceError('Cannot find a socket to connect to Discord')
-
-    def _get_pipe(self) -> str:
-        if sys.platform == 'win32':
-            # Windows pipe
-            return R'\\.\pipe\\' + SOCKET_NAME
-
-        # Unix pipe
-        for env in ('XDG_RUNTIME_DIR', 'TMPDIR', 'TMP', 'TEMP'):
-            path = os.environ.get(env)
-            if path is not None:
-                return os.path.join(path, SOCKET_NAME)
-
-        return os.path.join('/tmp/', SOCKET_NAME)
-
-    def _try_socket(self, pipe: str, i: int) -> None:
-        if sys.platform == 'win32':
-            self._socket = open(pipe.format(i), 'rb+')
-        else:
-            self._socket = socket.socket(socket.AF_UNIX)
-            self._socket.connect(pipe.format(i))
+        self._socket._close()
 
     def _handshake(self) -> None:
-        data = {
-            'v': 1,
-            'client_id': self.client_id,
-        }
-        self._send(data, OpCode.HANDSHAKE)
-        _, data = self._read()
+        self._send({'v': 1, 'client_id': self.client_id}, OpCode.HANDSHAKE)
+        data = self._read()
 
         if data.get('evt') != 'READY':
             raise PresenceError('Discord returned an error response after a handshake request')
 
-    def _read(self) -> tuple[int, dict[str, Any]]:
+    def _read(self) -> dict[str, Any]:
         op, length = self._read_header()
-        payload = self._read_bytes(length)
-        decoded = payload.decode('utf-8')
+        decoded = self._read_bytes(length).decode('utf-8')
         data = json.loads(decoded)
-        return op, data
+        return cast(dict[str, Any], data)
 
     def _read_header(self) -> tuple[int, int]:
         return cast(tuple[int, int], struct.unpack('<ii', self._read_bytes(8)))
@@ -157,26 +120,14 @@ class Presence:
     def _read_bytes(self, size: int) -> bytes:
         encoded = b''
         while size > 0:
-            if sys.platform == 'win32':
-                encoded += self._socket.read(size)
-            else:
-                encoded += self._socket.recv(size)
-
+            encoded += self._socket._read(size)
             size -= len(encoded)
         return encoded
 
     def _send(self, payload: dict[str, Any], op: OpCode) -> None:
-        data_json = json.dumps(payload)
-        encoded = data_json.encode('utf-8')
+        encoded = json.dumps(payload).encode('utf-8')
         header = struct.pack('<ii', int(op), len(encoded))
-        self._write(header + encoded)
-
-    def _write(self, data: bytes) -> None:
-        if sys.platform == 'win32':
-            self._socket.write(data)
-            self._socket.flush()
-        else:
-            self._socket.sendall(data)
+        self._socket._write(header + encoded)
 
     def __enter__(self) -> 'Presence':
         return self
@@ -188,3 +139,76 @@ class Presence:
         exc_traceback: TracebackType | None,
     ) -> None:
         self.close()
+
+class _Socket(ABC):
+    @abstractmethod
+    def __init__(self) -> None:
+        pass
+
+    @abstractmethod
+    def _read(self, size: int) -> bytes:
+        pass
+
+    @abstractmethod
+    def _write(self, data: bytes) -> None:
+        pass
+
+    @abstractmethod
+    def _close(self) -> None:
+        pass
+
+class _UnixSocket(_Socket):
+    def __init__(self) -> None:
+        pipe = os.path.join(self._get_pipe_path(), SOCKET_NAME)
+
+        # Try to connect to a socket, starting from 0 up to 9
+        for i in range(10):
+            try:
+                self._sock = socket.socket(socket.AF_UNIX)
+                self._sock.connect(pipe.format(i))
+                break
+            except FileNotFoundError:
+                pass
+        else:
+            raise PresenceError('Cannot find a Unix socket to connect to Discord')
+
+    def _get_pipe_path(self) -> str:
+        for env in ('XDG_RUNTIME_DIR', 'TMPDIR', 'TMP', 'TEMP'):
+            path = os.environ.get(env)
+            if path is not None:
+                return path
+
+        return '/tmp/'
+    
+    def _read(self, size: int) -> bytes:
+        return self._sock.recv(size)
+    
+    def _write(self, data: bytes) -> None:
+        self._sock.sendall(data)
+
+    def _close(self) -> None:
+        self._sock.close()
+    
+class _WindowsSocket(_Socket):
+    def __init__(self) -> None:
+        pipe = R'\\.\pipe\\' + SOCKET_NAME
+
+        # Try to connect to a socket, starting from 0 up to 9
+        for i in range(10):
+            try:
+                self._buffer = open(pipe.format(i), 'rb+')
+                break
+            except FileNotFoundError:
+                pass
+        else:
+            raise PresenceError('Cannot find a Windows socket to connect to Discord')
+    
+    def _read(self, size: int) -> bytes:
+        return self._buffer.read(size)
+    
+    def _write(self, data: bytes) -> None:
+        self._buffer.write(data)
+        self._buffer.flush()
+
+    def _close(self) -> None:
+        self._buffer.close()

--- a/discordrp/presence.py
+++ b/discordrp/presence.py
@@ -35,7 +35,6 @@ class Presence:
 
     def __init__(self, client_id: str):
         self.client_id = client_id
-        self._platform = sys.platform
         self._socket: Any = None
 
         # Connect to Discord IPC
@@ -115,7 +114,7 @@ class Presence:
             raise PresenceError('Cannot find a socket to connect to Discord')
 
     def _get_pipe(self) -> str:
-        if self._platform == WINDOWS:
+        if sys.platform == 'win32':
             # Windows pipe
             return R'\\.\pipe\\' + SOCKET_NAME
 
@@ -158,7 +157,7 @@ class Presence:
     def _read_bytes(self, size: int) -> bytes:
         encoded = b''
         while size > 0:
-            if self._platform == WINDOWS:
+            if sys.platform == 'win32':
                 encoded += self._socket.read(size)
             else:
                 encoded += self._socket.recv(size)
@@ -173,7 +172,7 @@ class Presence:
         self._write(header + encoded)
 
     def _write(self, data: bytes) -> None:
-        if self._platform == WINDOWS:
+        if sys.platform == 'win32':
             self._socket.write(data)
             self._socket.flush()
         else:

--- a/discordrp/presence.py
+++ b/discordrp/presence.py
@@ -6,7 +6,7 @@ import sys
 
 from abc import ABC, abstractmethod
 from enum import IntEnum
-from typing import Any, cast
+from typing import Any, Optional, cast
 from types import TracebackType
 from uuid import uuid4
 
@@ -44,7 +44,7 @@ class Presence:
         # Send a handshake request
         self._handshake()
 
-    def set(self, activity: dict[str, Any] | None) -> None:
+    def set(self, activity: Optional[dict[str, Any]]) -> None:
         """
         Sends an activity payload to Discord.
         :param activity: A dictionary of this format:
@@ -134,9 +134,9 @@ class Presence:
 
     def __exit__(
         self,
-        exc_type: type[BaseException] | None,
-        exc_value: BaseException | None,
-        exc_traceback: TracebackType | None,
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        exc_traceback: Optional[TracebackType],
     ) -> None:
         self.close()
 

--- a/discordrp/presence.py
+++ b/discordrp/presence.py
@@ -128,7 +128,7 @@ class Presence:
         return os.path.join('/tmp/', SOCKET_NAME)
 
     def _try_socket(self, pipe: str, i: int) -> None:
-        if self._platform == WINDOWS:
+        if sys.platform == 'win32':
             self._socket = open(pipe.format(i), 'rb+')
         else:
             self._socket = socket.socket(socket.AF_UNIX)

--- a/discordrp/presence.py
+++ b/discordrp/presence.py
@@ -183,8 +183,8 @@ class Presence:
 
     def __exit__(
         self,
-        exc_type: type[BaseException],
-        exc_value: BaseException,
-        exc_traceback: TracebackType
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        exc_traceback: TracebackType | None,
     ) -> None:
         self.close()

--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,5 @@ setup(
         'Typing :: Typed',
     ],
     python_requires='>=3.9',
+    package_data={"discordrp": ["py.typed"]},
 )


### PR DESCRIPTION
Just upstreaming some more of the changes I've made in my copy of your library (https://github.com/Amund211/prism/commit/358bd76b86efe83ed393b6482587d761ae742fb2), though a bit less invasive this time. Feel free to pick and choose which commits you want or don't want.

Summary of the changes:
- Made explicit that `Presence` is exported from `__init__.py` (`mypy` was complaining about this)
- Added some more type hints in `presence.py` to make it pass `mypy --strict` (there are still some `Any` types and 1 call to `cast`
- Added a `py.typed` marker. This makes the type hints visible to people using the library, as before you would get an error that the module was installed, but could not be type-checked
- Added `PresenceError` as an export from `__init__.py`
- Fix type-checking on windows
- Always do platform check the same way (ref last commit)